### PR TITLE
Adds support for Turnstile action and turnstileCData optional params

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ solution.v4['captcha_output']
 solution = client.decode_turnstile!(
   website_key:    'xyz',
   website_url:    'http://example.com/example=1',
+  # action:         'contact_form',           # OPTIONAL
+  # cdata:          'xyz',                    # OPTIONAL
   # proxy_type:     'http',                   # OPTIONAL
   # proxy_address:  '127.0.0.1',              # OPTIONAL
   # proxy_port:     '8080',                   # OPTIONAL
@@ -226,6 +228,8 @@ solution.token
 
 - `website_key`: the site key for the Turnstile.
 - `website_url`: the URL of the page with the Turnstile challenge.
+- `action`: optional parameter. Turnstile challenge unique action.
+- `cdata`: optional parameter. Turnstile challenge cData token.
 - `proxy_type`: optional parameter. Proxy connection protocol.
 - `proxy_address`: optional parameter. The proxy address.
 - `proxy_port`: optional parameter. The proxy port.

--- a/lib/anti_captcha/client.rb
+++ b/lib/anti_captcha/client.rb
@@ -227,6 +227,8 @@ module AntiCaptcha
     # @param [Hash] options Options hash.
     #   @option options [String]  :website_url
     #   @option options [String]  :website_key
+    #   @option options [String]  :action
+    #   @option options [String]  :cdata
     #
     # @param [Hash] proxy Not mandatory. A hash with configs of the proxy that
     #                     has to be used. Defaults to `nil`.
@@ -342,9 +344,11 @@ module AntiCaptcha
 
       when 'TurnstileTask'
         args[:task] = {
-          type:       'TurnstileTask',
-          websiteURL: options[:website_url],
-          websiteKey: options[:website_key],
+          type:           'TurnstileTask',
+          websiteURL:     options[:website_url],
+          websiteKey:     options[:website_key],
+          action:         options[:action],
+          turnstileCData: options[:cdata],
         }
 
       else

--- a/lib/anti_captcha/version.rb
+++ b/lib/anti_captcha/version.rb
@@ -1,4 +1,4 @@
 module AntiCaptcha
-  VERSION = "2.5.0"
+  VERSION = "2.6.0"
   USER_AGENT = "AntiCaptcha/Ruby v#{VERSION}"
 end


### PR DESCRIPTION
## Context
This project aims to add support for `action` and `turnstileCData` optional Cloudflare Turnstile captcha parameters.
AntiCaptcha documentation: https://anti-captcha.com/apidoc/task-types/TurnstileTaskProxyless